### PR TITLE
Timer object stays in the running state for one extra cycle after running_count is being exhausted

### DIFF
--- a/timer.cpp
+++ b/timer.cpp
@@ -71,15 +71,14 @@ void Timer::update() {
 
 		if(interval_is_setted) {
 			if(current_time - last_interval_time >= interval) {
-				if(repeat_count == 0) {
-					stop();
-					return ;
-				} else if(repeat_count > 0) {
-					repeat_count -= 1;
-				}
-				call();
-				last_interval_time = current_time;
+                call();
+                repeat_count -= 1;
+                if(repeat_count == 0) {
+                    stop();
+                    return;
+                }
 
+                last_interval_time = current_time;
 			}
 		}
 	}

--- a/timer.cpp
+++ b/timer.cpp
@@ -71,14 +71,14 @@ void Timer::update() {
 
 		if(interval_is_setted) {
 			if(current_time - last_interval_time >= interval) {
-                call();
-                repeat_count -= 1;
-                if(repeat_count == 0) {
-                    stop();
-                    return;
-                }
+				call();
+				repeat_count -= 1;
+				if(repeat_count == 0) {
+					stop();
+					return;
+				}
 
-                last_interval_time = current_time;
+				last_interval_time = current_time;
 			}
 		}
 	}


### PR DESCRIPTION
Minimal example:

```
#include "timer.h"

Timer timer;

void callback() {
  Serial.println("Timer end!");
}

void setup()
{
  Serial.begin(9600);

  timer.setTimeout(1000);
  timer.setCallback(callback);
  timer.start();
}

void loop()
{
  if (timer.isRunning()) {
    Serial.println(timer.getElapsedTime());
  }

  timer.update();
}
```

... provides this output:

```
...
985
990
996
Timer end!
1001
1019
1026
...
1999
```