### PR TITLE
Fixed so timers can run indefinitely

### DIFF
--- a/timer.cpp
+++ b/timer.cpp
@@ -72,7 +72,8 @@ void Timer::update() {
 		if(interval_is_setted) {
 			if(current_time - last_interval_time >= interval) {
 				call();
-				repeat_count -= 1;
+				if(repeat_count > 0)
+					repeat_count -= 1;
 				if(repeat_count == 0) {
 					stop();
 					return;


### PR DESCRIPTION
As discussed, this fixes the issue where timers stop running after 65536 iterations because of signed int overflow from -1 back to 0